### PR TITLE
Add Travis testing facility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+os:
+  - linux
+env:
+  - TEST_SUITE=gap
+  - TEST_SUITE=hpcgap
+language: c
+compiler:
+  - gcc
+  - clang
+branches:
+  only:
+    - master
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libgmp3-dev
+script:
+  - ./run_tests.sh $TEST_SUITE

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Maybe there's a better way to do this
+set -e
+
+mkdir tmp
+cd tmp
+
+case $1 in
+    gap)
+        git clone --depth=50 https://github.com/gap-system/gap.git gap
+        cd gap  
+        ./configure --with-gmp=system
+        make
+        mkdir pkg
+        cd pkg
+        wget ftp://ftp.gap-system.org/pub/gap/gap47/tar.gz/packages/GAPDoc-1.5.1.tar.gz
+        tar xvzf GAPDoc-1.5.1.tar.gz 2> /dev/null
+        ln -s ../../.. io
+        cd io
+        sh autogen.sh
+        ./configure
+        make
+        cd ../..
+        ;;
+    hpcgap)
+        git clone --depth=50 -b hpcgap-default https://github.com/gap-system/gap.git gap
+        cd gap
+        git clone --depth=50 https://github.com/gap-system/ward extern/ward
+        ./make.hpc WARD="extern/ward" ZMQ=no GMP=system
+        cd pkg
+        ln -s ../../.. io
+        cd io
+        sh autogen.sh
+        ./configure CFLAGS="`cat ../io/tmp/gap/build/cflags`"
+        make
+        cd ../..
+    ;;
+esac
+echo "Read(\"pkg/io/tst/testall.g\"); quit;" | sh bin/gap.sh | tee testlog.txt | grep --colour=always -E "########> Diff|$"
+( ! grep "########> Diff" testlog.txt )


### PR DESCRIPTION
* A .travis.yml file that does the basic setup and calls run_tests.sh
* The script run_tests.sh which takes as a first parameter gap or hpcgap
  as the testsuite and runs the appropriate gap branch.
* The script only runs io/tst/testall.g.
* There is a lot of room for improvement to this script, it could become
  a standard testing script for packages
* We need to still specify tests to run in testall.g